### PR TITLE
CI: Do not build and publish OCI images on GHA PRs from non-members

### DIFF
--- a/.github/workflows/oci.yml
+++ b/.github/workflows/oci.yml
@@ -63,6 +63,7 @@ jobs:
   oci:
     needs: build_and_test
     runs-on: ubuntu-latest
+    if: ${{ ! (startsWith(github.actor, 'dependabot') || github.event.pull_request.head.repo.fork ) }}
 
     steps:
       - name: Acquire sources


### PR DESCRIPTION
The OCI image build machinery can't upload to GHCR when running on behalf of non-members.