### PR TITLE
Testing: Update to cratedb-toolkit 0.0.4, using upstream pytest fixture

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,12 +98,11 @@ release = [
   "twine<5",
 ]
 test = [
-  "cratedb-toolkit==0.0.3",
+  "cratedb-toolkit[testing]==0.0.4",
   "pytest<9",
   "pytest-asyncio-cooperative",
   "pytest-cov<5",
   "pytest-mqtt",
-  "testcontainers",
 ]
 [project.urls]
 changelog = "https://github.com/daq-tools/lorrystream/blob/main/CHANGES.rst"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,39 +3,14 @@
 # See LICENSE file for more information.
 
 import pytest
-import sqlalchemy as sa
-from cratedb_toolkit.testing.testcontainers.cratedb import CrateDBContainer
 
 from lorrystream.util.common import setup_logging
 
 
-class CrateDBFixture:
-    def __init__(self):
-        self.cratedb = None
-        self.setup()
-
-    def setup(self):
-        self.cratedb = CrateDBContainer("crate/crate:nightly")
-        self.cratedb.start()
-
-    def finalize(self):
-        self.cratedb.stop()
-
-    def reset(self):
-        database_url = self.cratedb.get_connection_url()
-        sa_engine = sa.create_engine(database_url)
-        with sa_engine.connect() as conn:
-            conn.exec_driver_sql("DROP TABLE IF EXISTS testdrive;")
-
-    def get_connection_url(self, *args, **kwargs):
-        return self.cratedb.get_connection_url(*args, **kwargs)
-
-
-@pytest.fixture(scope="function")
-def cratedb():
-    fixture = CrateDBFixture()
-    yield fixture
-    fixture.finalize()
+@pytest.fixture
+def cratedb(cratedb_service):
+    cratedb_service.reset(["testdrive"])
+    yield cratedb_service
 
 
 setup_logging()


### PR DESCRIPTION
## About
CrateDB's adapter for "Testcontainers for Python" is maturing, so this patch is the next consequential step in code shuffling. By properly bringing corresponding code into the upstream implementation, this patch gets rid of relevant boilerplate code. Thanks for your support on all things yak shaving, @pilosus and @surister.

## References
- GH-47
- https://github.com/crate-workbench/cratedb-toolkit/pull/82
- https://github.com/crate-workbench/cratedb-toolkit/pull/113
