### PR TITLE
Dependencies: Permit any version of commons-codec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ dependencies = [
   "click<9",
   "colorama<1",
   "colorlog",
-  "commons-codec==0.0.3",
+  "commons-codec",
   "dask",
   "funcy",
   "influxdb",


### PR DESCRIPTION
## Problem
When pinning `commons-codec`  too eagerly, we are running into dependency woes quickly.

## References
https://github.com/crate/cratedb-toolkit/actions/runs/10418800775/job/28855632349?pr=224#step:6:344

## Solution
This patch intends to reduce dependency hell situation while things are yet very much in flux.