### PR TITLE
Dependencies: Fix problems with `commons-codec`

### DIFF
--- a/lorrystream/process/kinesis_cratedb_lambda.py
+++ b/lorrystream/process/kinesis_cratedb_lambda.py
@@ -24,7 +24,7 @@ Resources:
 # /// script
 # requires-python = ">=3.9"
 # dependencies = [
-#   "commons-codec==0.0.3",
+#   "commons-codec==0.0.5",
 #   "sqlalchemy-cratedb==0.38.0",
 # ]
 # ///


### PR DESCRIPTION
By relaxing one dependency constraint, keeping up succeeding builds might be easier than before when it comes to dependency issues. If this causes more runtime errors again, we will have to re-adjust our thinking again.