### PR TITLE
Chore: Update Dockerfile with new syntax about ENV directives

### DIFF
--- a/release/oci/Dockerfile
+++ b/release/oci/Dockerfile
@@ -6,8 +6,8 @@
 
 FROM python:3.12-slim-bullseye
 
-ENV DEBIAN_FRONTEND noninteractive
-ENV TERM linux
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TERM=linux
 
 # Install Git, it is needed for `versioningit`.
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache


### PR DESCRIPTION
## Problem
The admonition raised by GHA check warnings is:

> Legacy key/value format with whitespace separator should not be used
>
> LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format
More info: https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/