### PR TITLE
Dependencies: Unpin commons-codec, to always use the latest version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## in progress
+- Dependencies: Unpin commons-codec, to always use the latest version
 
 ## 2024-08-16 v0.0.4
 - Dependencies: Update to `commons-codec` version 0.0.6

--- a/lorrystream/process/kinesis_cratedb_lambda.py
+++ b/lorrystream/process/kinesis_cratedb_lambda.py
@@ -24,7 +24,7 @@ Resources:
 # /// script
 # requires-python = ">=3.9"
 # dependencies = [
-#   "commons-codec==0.0.6",
+#   "commons-codec",
 #   "sqlalchemy-cratedb==0.38.0",
 # ]
 # ///


### PR DESCRIPTION
What the title says.