### PR TITLE
Chore: Fix software tests about Kinesis/DynamoDB

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "daily"
 
   - package-ecosystem: "docker"
     directory: "/release/oci"

--- a/.github/workflows/oci.yml
+++ b/.github/workflows/oci.yml
@@ -6,7 +6,6 @@ on:
     tags:
       - '*.*.*'
   pull_request:
-    branches: [ main ]
 
   schedule:
     - cron: '0 06 * * *' # every day at 06am

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
   # Allow job to be triggered manually.
   workflow_dispatch:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+# https://docs.codecov.io/docs/common-recipe-list
+# https://docs.codecov.io/docs/commit-status#patch-status
+
+coverage:
+  status:
+
+    project:
+      default:
+        target: auto
+        threshold: 5%
+
+    patch:
+      default:
+        informational: true

--- a/lorrystream/process/kinesis_cratedb_lambda.py
+++ b/lorrystream/process/kinesis_cratedb_lambda.py
@@ -86,7 +86,7 @@ elif MESSAGE_FORMAT == "dynamodb":
 # TODO: Examine long-running jobs about successful reconnection behavior.
 try:
     engine = sa.create_engine(SINK_SQLALCHEMY_URL, echo=SQL_ECHO)
-    connection = engine.connect()
+    connection: sa.engine.Connection = engine.connect()
     logger.info(f"Connection to sink database succeeded: {SINK_SQLALCHEMY_URL}")
 except Exception as ex:
     logger.exception(f"Connection to sink database failed: {SINK_SQLALCHEMY_URL}")
@@ -123,7 +123,7 @@ def handler(event, context):
             # Process record.
             operation = cdc.to_sql(record_data)
             connection.execute(sa.text(operation.statement), operation.parameters)
-            connection.commit()
+            connection.commit()  # type: ignore[attr-defined]
 
             # Bookkeeping.
             cur_record_sequence_number = record["kinesis"]["sequenceNumber"]

--- a/lorrystream/streamz/sinks.py
+++ b/lorrystream/streamz/sinks.py
@@ -7,7 +7,7 @@ import typing as t
 
 import pandas as pd
 import sqlalchemy as sa
-from sqlalchemy import Engine
+from sqlalchemy.engine import Engine
 from streamz import Sink, Stream
 
 from lorrystream.exceptions import InvalidSinkError

--- a/lorrystream/util/about.py
+++ b/lorrystream/util/about.py
@@ -87,7 +87,7 @@ class AboutReport:
         import sqlalchemy.dialects
 
         subsection("SQLAlchemy")
-        print(bullet_item(sqlalchemy.dialects.__all__, label="Dialects built-in"))
+        print(bullet_item(sqlalchemy.dialects.__all__, label="Dialects built-in"))  # type: ignore[attr-defined]
         dialects: t.List[str]
         if sys.version_info >= (3, 10):
             eps = entry_points(group="sqlalchemy.dialects")
@@ -95,7 +95,7 @@ class AboutReport:
         else:
             dialects = []
         print(bullet_item(dialects, label="Dialects 3rd-party"))
-        print(bullet_item(sqlalchemy.dialects.plugins.impls.keys(), label="Plugins"))
+        print(bullet_item(sqlalchemy.dialects.plugins.impls.keys(), label="Plugins"))  # type: ignore[attr-defined]
         print()
 
         # fsspec

--- a/lorrystream/util/data.py
+++ b/lorrystream/util/data.py
@@ -55,7 +55,7 @@ def get_sqlalchemy_dialects() -> t.List[str]:
 
     import sqlalchemy.dialects
 
-    builtins = sqlalchemy.dialects.__all__
+    builtins = sqlalchemy.dialects.__all__  # type: ignore[attr-defined]
     more: t.List
     if sys.version_info >= (3, 10):
         eps = entry_points(group="sqlalchemy.dialects")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ dependencies = [
   "click<9",
   "colorama<1",
   "colorlog",
-  "commons-codec",
+  "commons-codec==0.0.22",
   "dask",
   "funcy",
   "influxdb",

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -32,7 +32,15 @@ def test_kinesis_dynamodb_cratedb_lambda_basic(mocker, cratedb, reset_handler):
     mocker.patch.dict(os.environ, handler_environment)
 
     # Provision CrateDB.
-    cratedb.database.run_sql('CREATE TABLE "testdrive-dynamodb-cdc" (data OBJECT(DYNAMIC));')
+    cratedb.database.run_sql(
+        """
+        CREATE TABLE "testdrive-dynamodb-cdc" (
+            pk OBJECT(STRICT) AS ("device" STRING PRIMARY KEY, "timestamp" STRING PRIMARY KEY),
+            data OBJECT(DYNAMIC),
+            aux OBJECT(IGNORED)
+        );
+    """
+    )
 
     # Invoke Lambda handler.
     from lorrystream.process.kinesis_cratedb_lambda import handler
@@ -45,7 +53,9 @@ def test_kinesis_dynamodb_cratedb_lambda_basic(mocker, cratedb, reset_handler):
 
     records = cratedb.database.run_sql('SELECT * FROM "testdrive-dynamodb-cdc";', records=True)
     assert records[0] == {
-        "data": {"temperature": 42.42, "humidity": 84.84, "device": "foo", "timestamp": "2024-07-12T01:17:42"}
+        "pk": {"device": "foo", "timestamp": "2024-07-12T01:17:42"},
+        "data": {"temperature": 42.42, "humidity": 84.84},
+        "aux": {},
     }
 
 
@@ -69,7 +79,15 @@ def test_kinesis_dynamodb_cratedb_lambda_batch(mocker, cratedb, reset_handler):
     mocker.patch.dict(os.environ, handler_environment)
 
     # Provision CrateDB.
-    cratedb.database.run_sql('CREATE TABLE "testdrive-dynamodb-cdc" (data OBJECT(DYNAMIC));')
+    cratedb.database.run_sql(
+        """
+        CREATE TABLE "testdrive-dynamodb-cdc" (
+            pk OBJECT(STRICT) AS ("device" STRING PRIMARY KEY, "timestamp" STRING PRIMARY KEY),
+            data OBJECT(DYNAMIC),
+            aux OBJECT(IGNORED)
+        );
+    """
+    )
 
     # Invoke Lambda handler.
     from lorrystream.process.kinesis_cratedb_lambda import handler
@@ -83,7 +101,9 @@ def test_kinesis_dynamodb_cratedb_lambda_batch(mocker, cratedb, reset_handler):
 
     records = cratedb.database.run_sql('SELECT * FROM "testdrive-dynamodb-cdc";', records=True)
     assert records[0] == {
-        "data": {"temperature": 42.42, "humidity": 84.84, "device": "foo", "timestamp": "2024-07-12T01:17:42"}
+        "pk": {"device": "foo", "timestamp": "2024-07-12T01:17:42"},
+        "data": {"temperature": 42.42, "humidity": 84.84},
+        "aux": {},
     }
 
 


### PR DESCRIPTION
## Problem

CI displayed unrelated errors on other PRs, both by humans, and by Dependabot.

```
FAILED tests/test_process.py::test_kinesis_dynamodb_cratedb_lambda_basic - SystemExit: 5
FAILED tests/test_process.py::test_kinesis_dynamodb_cratedb_lambda_batch - AssertionError: assert {'batchItemFailures': [{'itemIdentifier': ''}]} == {'batchItemFailures': []}
```
-- https://github.com/daq-tools/lorrystream/actions/runs/15581626172/job/43878060172?pr=162#step:5:1341

## References

- GH-162
- GH-164
- GH-166
- GH-168
